### PR TITLE
Change paste behavior to allow last paste to be moved to top of list

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
                     "type": "integer",
                     "minimum": 1,
                     "default": 12,
-                    "description": "Maximum number of items saved in clipboard"
+                    "description": "Maximum number of items saved in clipboard",
+                    "pasteBehavior": "keepLastPaste"
                 }
             }
         },


### PR DESCRIPTION
[Issue #5](https://github.com/aefernandes/vscode-clipboard-history-extension/issues/5)
Added a config option to change the behavior of paste action so it keeps the last pasted item on the top of the list: `"pasteBehavior": "keepLastPaste"` can be set in `package.json`, otherwise the previous behavior will remain. Note that I also changed the way the "regular" paste works so that it actually fetches this most recent pasted item.
Fixed a minor bug on pasteSelected caused by the param being undefined.
Code cleanup and standardisation (a few missing ;'s, changed some let/vars for const and removed unused code lines).